### PR TITLE
Replaced DBI usage in MySQL app monitor to reduce RSS memory usage.

### DIFF
--- a/Linode/Longview/DataGetter/Applications/MySQL.sql
+++ b/Linode/Longview/DataGetter/Applications/MySQL.sql
@@ -1,0 +1,9 @@
+SHOW /*!50002 GLOBAL */ STATUS
+WHERE Variable_name IN ("Com_select", "Com_insert", "Com_update", "Com_delete",
+                        "slow_queries", "Bytes_sent", "Bytes_received",
+                        "Connections", "Max_used_connections",
+                        "Aborted_Connects", "Aborted_Clients",
+                        "Qcache_queries_in_cache", "Qcache_hits",
+                        "Qcache_inserts", "Qcache_not_cached",
+                        "Qcache_lowmem_prunes");
+SHOW /*!50002 GLOBAL */ VARIABLES LIKE "version";


### PR DESCRIPTION
The DBI module with a loaded MySQL driver costs approx 2000 kB RSS memory, which is really only used for running two SQL queries once per minute.

So, a more memory-efficient solution is to use the MySQL command-line tools instead. This patch does just that. It is still a bit rough on the edges, since it assumes a "mysql" command on the path. Should probably support config and check a few standard locations as well.

```
VmRSS with DBI:     16528 kB 
VmRSS without DBI:  14552 kB
```

If this improvement is something that you'd consider, please comment on this PR. I'll clean up the code a bit as mentioned above.
