### PR TITLE
Changed to load and run all data getters in a child process

### DIFF
--- a/Linode/Longview.pl
+++ b/Linode/Longview.pl
@@ -92,19 +92,15 @@ my $stats = {
 
 _prep_for_main();
 
-my ($quit, $data, $reload) = (0, {}, 0);
+my ($quit, $reload) = (0, 0);
 while (!$quit) {
 	if ($reload){
 		reload_modules();
 		$reload = 0;
 	}
 	my $sleep = $SLEEP_TIME;
-	$data->{timestamp} = time;
-	get($_,$data,) for @{run_order()};
 
-	constant_push($stats->{payload},$data);
-	$data = {};
-
+	constant_push($stats->{payload}, get_data());
 	$stats->{timestamp} = time;
 	my $req = post($stats);
 

--- a/Linode/Longview.pl
+++ b/Linode/Longview.pl
@@ -94,8 +94,8 @@ _prep_for_main();
 
 my ($quit, $reload) = (0, 0);
 while (!$quit) {
-	if ($reload){
-		reload_modules();
+	if ($reload) {
+		# Nothing to do, all config reloads each run
 		$reload = 0;
 	}
 	my $sleep = $SLEEP_TIME;
@@ -133,7 +133,6 @@ sub _prep_for_main {
 
 	daemonize_self();
 	enable_debug_logging() if(defined $ARGV[0] && $ARGV[0] =~ /Debug/i);
-	load_modules();
 
 	$0 = 'linode-longview';
 	$SIG{TERM} = $SIG{INT} = $SIG{QUIT} = sub { $quit = 1 };

--- a/Linode/Longview/DataGetter.pm
+++ b/Linode/Longview/DataGetter.pm
@@ -34,7 +34,7 @@ use File::Basename;
 use File::Find;
 
 use Exporter 'import';
-our @EXPORT = qw(get load_modules reload_modules run_order);
+our @EXPORT = qw(get_data load_modules reload_modules run_order);
 
 our $dep_info = {};
 our $module_order = [];
@@ -135,6 +135,13 @@ sub print_unresolved {
 sub get {
   my ($key,$dataref) = @_;
   return "Linode::Longview::DataGetter::${key}"->get($dataref);
+}
+
+sub get_data {
+  my $data = {};
+  $data->{timestamp} = time;
+  get($_,$data,) for @{run_order()};
+  return $data;
 }
 
 1;

--- a/Linode/Longview/DataGetter.pm
+++ b/Linode/Longview/DataGetter.pm
@@ -59,7 +59,7 @@ sub load_modules {
     return if ! -f;
     return unless m/\.pm$/;
     my $module = $File::Find::name;
-    $logger->info("Loading module $module");
+    $logger->debug("Loading module $module");
     require $module;
     (my $rpath = $module)   =~ s|$module_path||;;
     (my $namepace = $rpath) =~ s|\.pm$||;
@@ -77,12 +77,6 @@ sub load_modules {
     s|\.pm$||;
     s|/|::|;
   }
-}
-
-sub reload_modules {
-  $logger->info("Reloading modules");
-  delete $INC{$_} for grep {m|$module_path|} (keys %INC);
-  load_modules();
 }
 
 sub resolve_deps {


### PR DESCRIPTION
The data getters are using quite a bit of RSS memory, which seems wasteful to me. So this patch changes the datagetter module to fork, load modules, fetch data and then serialize the result to JSON and pipe back to the parent process.

This is will cause some extra CPU work, but it also reduces the RSS memory by some 3500 kB. Using this run-time model fully, it might be possible to cut down some additional MB. For instance, the JSON serialization might not be needed for each run of the loop.

All in all, the longview agent is now down to 12.6 MB on my system. But it should be possible to cut that down by at least half in my mind.

Let me know if you find these type of optimizations interesting.