### PR TITLE
There's always one core

### DIFF
--- a/Linode/Longview/DataGetter/SysInfo.pm
+++ b/Linode/Longview/DataGetter/SysInfo.pm
@@ -64,7 +64,9 @@ sub get {
 			return $dataref;
 	};
 
-	$dataref->{INSTANT}->{'SysInfo.cpu.cores'} = grep {/^processor/} @cpu_info;
+	my $cores = grep {/^processor/} @cpu_info;
+	# There's always at least 1 core
+	$dataref->{INSTANT}->{'SysInfo.cpu.cores'} = $cores || 1;
 	#<<<
 	($dataref->{INSTANT}->{'SysInfo.cpu.type'} =
 		(map { /^(?:model name|Processor)\s+:(.*)$/; $1 || ()} @cpu_info)[0])


### PR DESCRIPTION
armhf /proc/cpuinfo is vastly different, and doesn't contain the word "processor".  As a result, the Raspberry Pi is believed to have 0 cores, resulting in the CPU graphs on the + view always being 100%.
