### PR TITLE
Longview/Logger.pm: Fix ambiguous date format

### DIFF
--- a/Linode/Longview/Logger.pm
+++ b/Linode/Longview/Logger.pm
@@ -25,7 +25,7 @@ for my $level ( keys %$levels ) {
     *{$level} = sub {
         my ( $self, $message ) = @_;
 
-        my $ts = strftime( '%m/%d %T', localtime );
+        my $ts = strftime( '%F %T', localtime );
         $self->{logger}->write(
             sprintf( '%s %s Longview[%i] - %s', $ts, uc($level), $$, $message ),
             $levels->{$level} );


### PR DESCRIPTION
Current date format (%m/%d %T, mm/dd HH:MM:SS) is ambiguous, %F %T (YYYY-mm-dd HH:MM:SS) is not.
