### PR TITLE
log format

### DIFF
--- a/Linode/Longview/Logger.pm
+++ b/Linode/Longview/Logger.pm
@@ -25,7 +25,7 @@ for my $level ( keys %$levels ) {
     *{$level} = sub {
         my ( $self, $message ) = @_;
 
-        my $ts = strftime( '%m/%d %T', localtime );
+        my $ts = strftime( '%F %T', localtime );
         $self->{logger}->write(
             sprintf( '%s %s Longview[%i] - %s', $ts, uc($level), $$, $message ),
             $levels->{$level} );


### PR DESCRIPTION
Currently "%m/%d %T" is used, this patch just changes it to "%F %T":

```
>>> time.strftime("%m/%d %T")
'07/22 10:12:33'
>>> time.strftime("%F %T")
'2014-07-22 10:15:55'
```
