### PR TITLE
Only remove longview files from /etc/linode

### DIFF
--- a/Extras/specs/centos-longview.spec
+++ b/Extras/specs/centos-longview.spec
@@ -82,5 +82,5 @@ if [ $1 -ge 1 ] ; then
 fi
 if [ $1 -eq 0 ]; then
     # package remove, not upgrade
-    rm -rf /etc/linode/
+    rm -rf /etc/linode/longview.*
 fi

--- a/Extras/specs/fedora-longview.spec
+++ b/Extras/specs/fedora-longview.spec
@@ -87,5 +87,5 @@ if [ $1 -ge 1 ] ; then
 fi
 if [ $1 -eq 0 ]; then
     # package remove, not upgrade
-    rm -rf /etc/linode/
+    rm -rf /etc/linode/longview.*
 fi

--- a/debian/linode-longview.postrm
+++ b/debian/linode-longview.postrm
@@ -13,5 +13,5 @@ fi
 
 if [ "$1" = "remove" -o "$1" = "purge" ]; then
 	update-rc.d -f longview remove
-	rm -rf /etc/linode/
+	rm -rf /etc/linode/longview.*
 fi


### PR DESCRIPTION
@dwfreed This look better to you?

Since we don't include the config files in the package we can't use the package manager to handle the config files.  Also, longview.key should not be saved since if you remove and then reinstall longview you would probably need a new key. 