### PR TITLE
Update YUM.pm to include all Repositories

### DIFF
--- a/Extras/Modules/Packages/YUM.pm
+++ b/Extras/Modules/Packages/YUM.pm
@@ -92,7 +92,7 @@ sub upgradable_pkgs {
 	my @pkg_list = qx(yum check-update);
 	my %pkgs;
 	for my $pkg (@pkg_list) {
-		if ( $pkg =~ m/^(\S+\.\S+)\s+(\S+)\s+\S+$/ ) {
+		if ( $pkg =~ m/^(\S+\.\S+)\s+(\S+)\s+\S+\s*$/ ) {
 			$pkgs{$1} = $2;
 		}
 	}


### PR DESCRIPTION
Only packages from the the repository (or repositories) with the longest name were included, need to allow for white space at the end of the line.