### PR TITLE
Prevent 'Use of uninitialized value' warnings

### DIFF
--- a/Linode/Longview/DataGetter/Processes.pm
+++ b/Linode/Longview/DataGetter/Processes.pm
@@ -65,7 +65,7 @@ sub process_info {
 		if ( $line =~ m/^VmRSS:\s+(.*)\s+kB/ )   { $proc{mem}  = $1; last; }
 	}
 
-	$proc{user}  = ( getpwuid( $proc{uid} ) )[0];
+	$proc{user}  = ( getpwuid( $proc{uid} ) )[0] || "";
 
 	# cpu
 	my ( $user_time, $system_time, $start_jiffies )


### PR DESCRIPTION
When processes running within docker containers are running as users without an entry in the host machine's /etc/passwd file, many warnings will appear in the log. While they're just warnings and could be ignored, they do produce a great deal of excess noise that would be better to prevent.

One solution would be to create user entries in the passwd file, but that really shouldn't be necessary. Instead we can just cast the user value to an empty string to prevent the warnings entirely.

This resolves #24 