### PR TITLE
Permit specifying custom host

### DIFF
--- a/Linode/Longview/DataGetter/Applications/MySQL.pm
+++ b/Linode/Longview/DataGetter/Applications/MySQL.pm
@@ -65,8 +65,13 @@ sub get {
 				1 );
 		}
 	}
+	
+	my $hostname = "localhost";
+	if ( exists( $creds->{host} ) ) {
+		$hostname = $creds->{host};
+	}
 
-	my $dbh = DBI->connect_cached( "DBI:mysql:host=localhost;", $creds->{username}, $creds->{password} ) or do {
+	my $dbh = DBI->connect_cached( "DBI:mysql:host=${hostname};", $creds->{username}, $creds->{password} ) or do {
 		return application_error( $dataref, $namespace,
 			'Unable to connect to the database: ' . $DBI::errstr,
 			2 );


### PR DESCRIPTION
**My Perl is very rusty so this should be taken with a strong grain of salt. I've not tested it as of yet.**

I'm running a MySQL server that for $REASONS has its unix socket inaccessible to the Linode agent. However, whenever you provide the string `localhost` to a MySQL client library, it's always going to go for the unix socket. My intent with this change is to permit me to provide `host 127.0.0.1` so it'll connect over the TCP socket that's open.