### PR TITLE
fix: add support for MariaDB

### DIFF
--- a/Linode/Longview/DataGetter/Applications/MySQL.pm
+++ b/Linode/Longview/DataGetter/Applications/MySQL.pm
@@ -35,7 +35,7 @@ use DBI;
 use Linode::Longview::Util qw(:APPLICATIONS slurp_file);
 
 our $DEPENDENCIES = ['Processes.pm'];
-our $SIGNATURES = ['mysqld'];
+our $SIGNATURES = ['mysqld', 'mariadbd'];
 my $namespace  = 'Applications.MySQL.';
 
 sub get {


### PR DESCRIPTION
Longview fails to collect statistics for MariaDB on Ubuntu 22.04, this resolves the issue. 