### PR TITLE
DI-28915: Security vulnerability fix cpanm download over http

### DIFF
--- a/Extras/install-dependencies.sh
+++ b/Extras/install-dependencies.sh
@@ -30,7 +30,7 @@ echo "Installing dependencies in to: $BASE_DIR"
 check_builddep make
 check_builddep cc
 
-http_fetch http://cpanmin.us /tmp/cpanm
+http_fetch https://cpanmin.us /tmp/cpanm
 chmod +x /tmp/cpanm
 
 echo "==== Installing Longview core dependencies ===="

--- a/Extras/specs/centos-longview.spec
+++ b/Extras/specs/centos-longview.spec
@@ -29,8 +29,8 @@ http_fetch() {
 		exit 1
 	fi
 }
-[ -e $OLDPWD/Extras/lib/perl5/Linux/Distribution.pm  ] || http_fetch http://cpansearch.perl.org/src/CHORNY/Linux-Distribution-0.23/lib/Linux/Distribution.pm $OLDPWD/Extras/lib/perl5/Linux/Distribution.pm
-[ -e $OLDPWD/Extras/lib/perl5/Try/Tiny.pm ] || http_fetch http://cpansearch.perl.org/src/ETHER/Try-Tiny-0.24/lib/Try/Tiny.pm $OLDPWD/Extras/lib/perl5/Try/Tiny.pm
+[ -e $OLDPWD/Extras/lib/perl5/Linux/Distribution.pm  ] || http_fetch https://cpansearch.perl.org/src/CHORNY/Linux-Distribution-0.23/lib/Linux/Distribution.pm $OLDPWD/Extras/lib/perl5/Linux/Distribution.pm
+[ -e $OLDPWD/Extras/lib/perl5/Try/Tiny.pm ] || http_fetch https://cpansearch.perl.org/src/ETHER/Try-Tiny-0.24/lib/Try/Tiny.pm $OLDPWD/Extras/lib/perl5/Try/Tiny.pm
 
 %install
 rm -rf %{buildroot}

--- a/Extras/specs/fedora-longview.spec
+++ b/Extras/specs/fedora-longview.spec
@@ -34,8 +34,8 @@ http_fetch() {
 		exit 1
 	fi
 }
-[ -e $OLDPWD/Extras/lib/perl5/Linux/Distribution.pm  ] || http_fetch http://cpansearch.perl.org/src/CHORNY/Linux-Distribution-0.23/lib/Linux/Distribution.pm $OLDPWD/Extras/lib/perl5/Linux/Distribution.pm
-[ -e $OLDPWD/Extras/lib/perl5/Try/Tiny.pm ] || http_fetch http://cpansearch.perl.org/src/ETHER/Try-Tiny-0.24/lib/Try/Tiny.pm $OLDPWD/Extras/lib/perl5/Try/Tiny.pm
+[ -e $OLDPWD/Extras/lib/perl5/Linux/Distribution.pm  ] || http_fetch https://cpansearch.perl.org/src/CHORNY/Linux-Distribution-0.23/lib/Linux/Distribution.pm $OLDPWD/Extras/lib/perl5/Linux/Distribution.pm
+[ -e $OLDPWD/Extras/lib/perl5/Try/Tiny.pm ] || http_fetch https://cpansearch.perl.org/src/ETHER/Try-Tiny-0.24/lib/Try/Tiny.pm $OLDPWD/Extras/lib/perl5/Try/Tiny.pm
 
 
 %install


### PR DESCRIPTION
Issue reported as part of DI-28915 - Longview install script downloads and executes cpanm over plain HTTP, enabling MITM RCE
So currently we are updating cpnam download over https.